### PR TITLE
Update manifest.json to support CipherCloud

### DIFF
--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -19,7 +19,7 @@
   ],
   "content_scripts": [
     {
-      "matches": ["https://*.salesforce.com/*", "https://*.visual.force.com/*", "https://*.lightning.force.com/*"],
+      "matches": ["https://*.salesforce.com/*", "https://*.visual.force.com/*", "https://*.lightning.force.com/*", "https://*salesforce-com*/*"],
       "all_frames": true,
       "css": [
         "button.css",


### PR DESCRIPTION
The Chrome-Salesforce-inspector does not start when entering SalesForce cloud via CipherCloud & domain. Adding the address is in format https://p-domaindc-my-salesforce-com.secgwde.domain.com/home/home.jsp and the proposed change should accept this address as valid one.