### PR TITLE
Fix matching with new Lightning URL format

### DIFF
--- a/addon/popup-test.js
+++ b/addon/popup-test.js
@@ -34,9 +34,9 @@ async function popupTest(test) {
   assertEquals(null, getRecordId(new URL("https://na1.visual.force.com/apex/VfPage?other=foo"))); // parameter containing 3 character non-ID
   assertEquals(null, getRecordId(new URL("https://na1.visual.force.com/apex/VfPage?other=foofoofoofoofoo"))); // parameter containing 15 character non-ID
   // Lightning Experience / Salesforce1
-  assertEquals("Account", getRecordId(new URL("https://na1.lightning.force.com/one/one.app?source=aloha#/sObject/Account/home?t=1473700726105"))); // lightning record home
-  assertEquals("Account", getRecordId(new URL("https://mydomain.lightning.force.com/one/one.app?source=aloha#/sObject/Account/home?t=1473700726105"))); // lightning record home with My Domain
-  assertEquals("001i0000007BlV0AAK", getRecordId(new URL("https://na1.lightning.force.com/one/one.app?source=aloha#/sObject/001i0000007BlV0AAK/view?t=1473700726105"))); // lightning record detail page
-  assertEquals("001i0000007BlV0AAK", getRecordId(new URL("https://na1.lightning.force.com/one/one.app?id=a37E0000000DV1c#/sObject/001i0000007BlV0AAK/view?t=1473700726105"))); // prefer standard
-  assertEquals("a37E0000000DV1c", getRecordId(new URL("https://na1.lightning.force.com/one/one.app?id=a37E0000000DV1c#/foo?t=1473700726105"))); // support non-standard
+  assertEquals("Account", getRecordId(new URL("https://na1.lightning.force.com/lightning/o/Account/home?t=1473700726105"))); // lightning record home
+  assertEquals("Account", getRecordId(new URL("https://mydomain.lightning.force.com/lightning/o/Account/home?t=1473700726105"))); // lightning record home with My Domain
+  assertEquals("001i0000007BlV0AAK", getRecordId(new URL("https://na1.lightning.force.com/lightning/r/001i0000007BlV0AAK/view?t=1473700726105"))); // lightning record detail page
+  assertEquals("001i0000007BlV0AAK", getRecordId(new URL("https://na1.lightning.force.com/lightning/r/001i0000007BlV0AAK/view?t=1473700726105&id=a37E0000000DV1c"))); // prefer standard
+  assertEquals("a37E0000000DV1c", getRecordId(new URL("https://na1.lightning.force.com/lightning/r/?id=a37E0000000DV1c#/foo?t=1473700726105"))); // support non-standard
 }

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -703,6 +703,9 @@ class Autocomplete extends React.PureComponent {
 }
 
 function getRecordId(href) {
+  console.log('Get record');
+  console.log('href');
+
   let url = new URL(href);
   // Find record ID from URL
   let searchParams = new URLSearchParams(url.search.substring(1));
@@ -718,7 +721,7 @@ function getRecordId(href) {
   }
   // Lightning Experience and Salesforce1
   if (url.hostname.endsWith(".lightning.force.com")) {
-    let match = url.hash.match(/\/sObject\/([a-zA-Z0-9]+)(?:\/|$)/);
+    let match = url.pathname.match(/\/r|o\/[a-zA-Z]+\/([a-zA-Z0-9]+)(?:\/|$)/);
     if (match) {
       return match[1];
     }


### PR DESCRIPTION
Critical update: https://developer.salesforce.com/blogs/2018/01/heres-need-know-new-url-format-lightning.html

Release note: https://docs.releasenotes.salesforce.com/en-us/spring18/release-notes/rn_general_enhanced_urls_cruc.htm

tl;dr:

`https://<lightning.domain.com>/one/one.app/#/sObject/Account/home` becomes `https://<lightning.domain.com>/lightning/o/Account/home`

and 

`https://<lightning.domain.com>/one/one.app#/sObject/<recordID>/view
` becomes `https://<lightning.domain.com>/lightning/r/Account/<recordID>/view`

Where `/r/` is for record and `/o/` is for home.
