### PR TITLE
Added proxy domains, handling domain extensions, handling encryption …

### DIFF
--- a/addon/manifest-template.json
+++ b/addon/manifest-template.json
@@ -16,6 +16,8 @@
     "https://*.salesforce.com/*",
     "https://*.force.com/*",
     "https://*.cloudforce.com/*",
+    "https://*.salesforce.com.us.cas.ms/*",
+    "https://*.force.com.us.cas.ms/*",
     "cookies"
   ],
   "content_scripts": [
@@ -24,6 +26,7 @@
         "https://*.salesforce.com/*",
         "https://*.visual.force.com/*",
         "https://*.lightning.force.com/*",
+        "https://*.lightning.force.com.us.cas.ms/*",
         "https://*.cloudforce.com/*"
       ],
       "all_frames": true,

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1195,7 +1195,7 @@ function getRecordId(href) {
   }
 
   // Lightning Experience and Salesforce1
-  if (url.hostname.endsWith(".lightning.force.com")) {
+  if (url.hostname.endsWith(".lightning.force.com") || url.hostname.endsWith(".lightning.force.com.us.cas.ms")) {
     let match;
 
     if (url.pathname == "/one/one.app") {


### PR DESCRIPTION
Hi Søren- our organization has enabled a Microsoft reverse-proxy to enhance security on our Salesforce instance.  This has resulted in two things that have caused the Salesforce inspector to no longer work properly on our application: (1) An extension of ".us.cas.ms" to our domain and (2) The encryption of our cookies.
 
To enable the inspector to work with these changes, I have made changes to these three files:
1) manifest-template.json: Added domains to "permissions" and "matches"
2) popup.js: Added the URL with the “us.cas.ms” extension to the lightning.force.com case in the "getRecordId" function, which finds the recordId based on the domain ending
3) background.js: A few additions to solve 2 problems: (a) Find cookies from the salesforce.com domain with or without a proxy extension (b) If the cookie and therefore org id is encrypted, we find the matching salesforce.com domain by finding a matching URL pattern across cookies
 
We hope you can accept these changes so that our users can continue to use this extension which has become part of many of their day-to-day operations.  Please let me know what feedback you may have so that I can improve or make modifications to the submitted code to get it into state where you can accept this PR.