### PR TITLE
Upgrade Salesforce API version to 55 - Summer'22

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Version 1.13
+===========
+
+General
+=======
+* Update to Salesforce API v 55.0 (Summer'22)
+
 Version 1.12
 ===========
 

--- a/addon/inspector.js
+++ b/addon/inspector.js
@@ -1,4 +1,4 @@
-export let apiVersion = "51.0";
+export let apiVersion = "55.0";
 export let sfConn = {
 
   async getSession(sfHost) {


### PR DESCRIPTION
Hello, I want to upgrade the API version to the latest being released by Salesforce.