### PR TITLE
add option to name query before saving

### DIFF
--- a/addon/data-export.css
+++ b/addon/data-export.css
@@ -116,6 +116,11 @@ h1 {
 .query-history {
   width: 9em;
 }
+.query-name {
+  width: 8em;
+  margin-top: 1px;
+  margin-left: 4px;
+}
 #export-help-btn {
   float: right;
   margin-top: 3px;


### PR DESCRIPTION
This PR will add an optional text input for naming queries before saving them.

More details about this change:
- This visual change only affects the "Saved queries" options, not the "Query history" options
- If no query name is provided, then the default name will be the query string itself (existing behavior)

With query name provided:
![2022-06-17_name-saved-query_with-name](https://user-images.githubusercontent.com/8731465/174357856-1bce639d-ce0f-4f9f-ad33-83d70f27fb65.png)

Without query name:
![2022-06-17_name-saved-query_without-name](https://user-images.githubusercontent.com/8731465/174357946-d3076596-bd89-437d-b534-60047af0d1e8.png)
