### PR TITLE
Upgrade to v56

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-Version 1.13
+Version 1.14
 ===========
 
 General

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,13 @@ Version 1.13
 
 General
 =======
+* Update to Salesforce API v 56.0 (Winter'23)
+
+Version 1.13
+===========
+
+General
+=======
 * Update to Salesforce API v 55.0 (Summer'22)
 
 Version 1.12

--- a/addon/inspector.js
+++ b/addon/inspector.js
@@ -1,4 +1,4 @@
-export let apiVersion = "55.0";
+export let apiVersion = "56.0";
 export let sfConn = {
 
   async getSession(sfHost) {


### PR DESCRIPTION
Hello, I want to upgrade the API version to Salesforce's latest release.

We can wait until Oct 15th, when all orgs are upgraded (the last date is Oct 14th).