### PR TITLE
Handle LocaleSidKeys with multiple underscores + (Latin)

### DIFF
--- a/addon/popup.js
+++ b/addon/popup.js
@@ -1235,7 +1235,8 @@ function getSfPathFromUrl(href) {
 function sfLocaleKeyToCountryCode(localeKey) {
   //Converts a Salesforce locale key to a lower case country code (https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) or "".
   if (!localeKey) { return ""; }
-  return localeKey.split("_").pop().toLowerCase();
+  const splitted = localeKey.split("_");
+  return splitted[(splitted.length > 1 && !localeKey.includes("_LATN_")) ? 1 : 0].toLowerCase();
 }
 
 window.getRecordId = getRecordId; // for unit tests


### PR DESCRIPTION
The current method isn't handling multiple underscores in LocalSidKey.
There are multiple values with 2 underscores:
- de_DE_EURO
- uz_LATN_UZ
- zh_CN_PINYIN
- zh_CN_STROKE
- zh_HK_STROKE
- zh_TW_STROKE

uz_LATN_UZ has been handled with an ad-hoc rule since LATN means Latin and the country is UZ.
One of the impact is the following flag, that is not showing correctly for the value de_DE_EURO (e.g.:):

![image](https://github.com/sorenkrabbe/Chrome-Salesforce-inspector/assets/12510531/c6cd1864-040d-47e5-a0f2-81b355cc7b99)
